### PR TITLE
TextAlign fix

### DIFF
--- a/src/texture.ts
+++ b/src/texture.ts
@@ -329,10 +329,18 @@ class Text extends Texture {
         context.textAlign = this.options.textAlign || 'left';
         context.textBaseline = this.options.textBaseline || 'top';
 
+        // Adjust x position based on text alignment
+        let xPosition = 0;
+        if (this.options.textAlign === 'center') {
+            xPosition = maxWidth / 2;
+        } else if (this.options.textAlign === 'right') {
+            xPosition = maxWidth;
+        }
+		
         // 3. Draw text
         let yOffset = 0;
         for (const line of lines) {
-            context.fillText(line, 0, yOffset);
+            context.fillText(line, xPosition, yOffset);
             yOffset += fontSize;
         }
 


### PR DESCRIPTION
Fixes a textAlign issue where the text gets cut-off when setting it to 'center' or'right'.

Eg:
<img width="395" height="155" alt="image" src="https://github.com/user-attachments/assets/235b9186-feb2-437a-9877-2884af63a653" />

Becomes:
<img width="398" height="134" alt="image" src="https://github.com/user-attachments/assets/362c71ad-9e06-4e8e-aedf-e1338e847188" />
